### PR TITLE
Reverse commit order after the buffer is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correct bug where saving without exiting reversed the commits displayed.
 
 ## [0.2.3] - 2019-01-03
 ### Changed

--- a/ftplugin/gitrebase.vim
+++ b/ftplugin/gitrebase.vim
@@ -15,13 +15,14 @@ if exists('g:ft_interactive_rebase_reverse')
 endif
 let g:ft_interactive_rebase_reverse = 1"
 
-" Reverse the order of all commits in the git interactive rebase screen.
+" Reverse the order of all commits in the git interactive rebase screen,
+" when this filetype (gitrebase) is loaded.
 call s:Reverse()
 
 " Set an autocmd to run when the Buffer is written
 augroup fe_interactive_rebase_reverse
 	autocmd!
-	" (Un)reverse the order of all commits in the git interactive rebase screen.
+	" Before saving (un)reverse the order of all commits.
 	autocmd BufWritePre <buffer> call s:Reverse()
 	" After saving reverse the order of the commits again.
 	autocmd BufWritePost <buffer> call s:Reverse()

--- a/ftplugin/gitrebase.vim
+++ b/ftplugin/gitrebase.vim
@@ -23,4 +23,6 @@ augroup fe_interactive_rebase_reverse
 	autocmd!
 	" (Un)reverse the order of all commits in the git interactive rebase screen.
 	autocmd BufWritePre <buffer> call s:Reverse()
+	" After saving reverse the order of the commits again.
+	autocmd BufWritePost <buffer> call s:Reverse()
 augroup END

--- a/ftplugin/gitrebase.vim
+++ b/ftplugin/gitrebase.vim
@@ -22,5 +22,5 @@ call s:Reverse()
 augroup fe_interactive_rebase_reverse
 	autocmd!
 	" (Un)reverse the order of all commits in the git interactive rebase screen.
-	autocmd BufWrite <buffer> call s:Reverse()
+	autocmd BufWritePre <buffer> call s:Reverse()
 augroup END


### PR DESCRIPTION
Restore the reversed display of commits after the buffer is written.

Now on save, we are:

- flipping the commits back to the original order
- saving the buffer
- putting the commits back in reverse order (the **new behavior added in this PR**)

This allows the user to save the buffer multiple times while writing the commit message.

See #9